### PR TITLE
Check for SuppressWarnings in quality checker

### DIFF
--- a/src/main/resources/cs240_checks.xml
+++ b/src/main/resources/cs240_checks.xml
@@ -90,6 +90,10 @@
             <message key="name.invalidPattern"
                      value="Interface type name ''{0}'' must match pattern ''{1}'' (A single letter, like 'T')."/>
         </module>
+        <module name="SuppressWarnings">
+            <property name="format" value="^unchecked$|^unused$"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>    
 
         <module name="NoCodeInFile"/>
 


### PR DESCRIPTION
Checks that methods are not allowed to use suppress warning annotations (unchecked & unused). This can be circumnavigated in a [few ways](https://checkstyle.sourceforge.io/checks/annotation/suppresswarnings.html#SuppressWarnings).