### PR TITLE
Exclude normal (non-block) strings from commented-out-code detection

### DIFF
--- a/src/main/java/edu/byu/cs240/checkstyle/readability/CommentedCode.java
+++ b/src/main/java/edu/byu/cs240/checkstyle/readability/CommentedCode.java
@@ -18,6 +18,7 @@ public class CommentedCode extends AbstractFileSetCheck {
 
     private static final Set<Character> CODE_LINE_END_CHARS = Set.of(';', ',', '{', '}', '(', ')', '/');
 
+    // STRINGS_REGEX matches strings that begin with an even number of non-escaped " chars
     private static final String STRINGS_REGEX = "^[^\"]*((?<!/)\"[^\"]*(?<!/)\"[^\"]*)*";
     private static final String BLOCK_COMMENT_START_REGEX = STRINGS_REGEX + "/\\*";
     private static final String BLOCK_COMMENT_END_REGEX = STRINGS_REGEX + "\\*/";

--- a/src/test/java/edu/byu/cs240/checkstyle/readability/CommentedCodeTest.java
+++ b/src/test/java/edu/byu/cs240/checkstyle/readability/CommentedCodeTest.java
@@ -54,6 +54,14 @@ class CommentedCodeTest extends CheckTest {
 
 
     @Test
+    @DisplayName("Should find no errors in code that has '/*' or related character sequences in a string")
+    public void should_FindNoErrors_when_commentInString() throws CheckstyleException {
+        String fileName = "testInputs/commentedCode/should_FindNoErrors_when_commentInString.java";
+        testFiles(0, fileName);
+    }
+
+
+    @Test
     @DisplayName("Should find errors in code that has code comments")
     public void should_FindErrors_when_CodeComments() throws CheckstyleException {
         String fileName = "testInputs/commentedCode/should_FindErrors_when_CodeComments.java";

--- a/src/test/resources/edu/byu/cs240/checkstyle/readability/testInputs/commentedCode/should_FindNoErrors_when_commentInString.java
+++ b/src/test/resources/edu/byu/cs240/checkstyle/readability/testInputs/commentedCode/should_FindNoErrors_when_commentInString.java
@@ -1,0 +1,38 @@
+import java.util.Scanner;
+
+class should_FindNoErrors_when_TextBlock {
+    public void notBananas() {
+        String notABananaToken = "/*";
+        String alsoNotABananaToken = "/**";
+        String stillNotABananaToken = "//";
+        String definitelyNotABananaToken = "///";
+        String dontEvenThinkAboutThisBeingABananaToken = "////";
+
+        String notABananaToken_withEndChar = "/*;";
+        String alsoNotABananaToken_withEndChar = "/**;";
+        String stillNotABananaToken_withEndChar = "//;";
+        String definitelyNotABananaToken_withEndChar = "///;";
+        String dontEvenThinkAboutThisBeingABananaToken_withEndChar = "////;";
+
+        Scanner scanner = new Scanner(System.in);
+        System.out.print("How many bananas? ");
+        String input = scanner.next();
+        int numBananas;
+        try {
+            numBananas = 0; // no bananas here...
+        }
+        catch (NumberFormatException e) {
+            System.out.println("Could not parse " + input + " as a number. No bananas.");
+            numBananas = 0;
+        }
+        for(int i = 0; i < numBananas; i++) {
+            System.out.println("Banana " + (i + 1));
+            System.out.println(myBananaToken);
+        }
+    }
+
+
+    public static void main(String[] args) {
+        new should_FindNoErrors_when_TextBlock().notBananas();
+    }
+}

--- a/src/test/resources/edu/byu/cs240/checkstyle/readability/testInputs/commentedCode/should_FindNoErrors_when_commentInString.java
+++ b/src/test/resources/edu/byu/cs240/checkstyle/readability/testInputs/commentedCode/should_FindNoErrors_when_commentInString.java
@@ -8,18 +8,30 @@ class should_FindNoErrors_when_TextBlock {
         String definitelyNotABananaToken = "///";
         String dontEvenThinkAboutThisBeingABananaToken = "////";
 
+        String notABananaToken_twice = "/*" + "/*";
+        String alsoNotABananaToken_twice = "/*" + "/*";
+        String stillNotABananaToken_twice = "//" + "//";
+        String definitelyNotABananaToken_twice = "///" + "///";
+        String dontEvenThinkAboutThisBeingABananaToken_twice = "////";
+
         String notABananaToken_withEndChar = "/*;";
         String alsoNotABananaToken_withEndChar = "/**;";
         String stillNotABananaToken_withEndChar = "//;";
         String definitelyNotABananaToken_withEndChar = "///;";
         String dontEvenThinkAboutThisBeingABananaToken_withEndChar = "////;";
 
+        String notABananaToken_twice_withEndChar = "/*;" + "/*;";
+        String alsoNotABananaToken_twice_withEndChar = "/**;" + "/**;";
+        String stillNotABananaToken_twice_withEndChar = "//;" + "//;";
+        String definitelyNotABananaToken_twice_withEndChar = "///;" + "///;";
+        String dontEvenThinkAboutThisBeingABananaToken_twice_withEndChar = "////;" + "////;";
+
         Scanner scanner = new Scanner(System.in);
         System.out.print("How many bananas? ");
         String input = scanner.next();
         int numBananas;
         try {
-            numBananas = 0; // no bananas here...
+            numBananas = 0; // aint no bananas here...
         }
         catch (NumberFormatException e) {
             System.out.println("Could not parse " + input + " as a number. No bananas.");


### PR DESCRIPTION
Resolves #2 