### PR TITLE
Remove Duplicated Code Duplicate Reports

### DIFF
--- a/src/main/java/edu/byu/cs240/checkstyle/decomposition/AbstractDuplicateCheck.java
+++ b/src/main/java/edu/byu/cs240/checkstyle/decomposition/AbstractDuplicateCheck.java
@@ -20,6 +20,8 @@ public abstract class AbstractDuplicateCheck extends AbstractCheck {
 
     protected int minComplexity = 50;
 
+    protected DetailAST inViolationAST = null;
+
 
     /**
      * Sets the minimum complexity of the check
@@ -44,6 +46,10 @@ public abstract class AbstractDuplicateCheck extends AbstractCheck {
             return;
         }
 
+        if(inViolationAST != null) {
+            return;
+        }
+
         int complexity = TreeUtils.astComplexity(ast);
         if (complexity < minComplexity) {
             return;
@@ -52,6 +58,7 @@ public abstract class AbstractDuplicateCheck extends AbstractCheck {
         for (DetailAST original : checkedAst.keySet()) {
             if (astEquals(original, ast)) {
                 logViolation(ast, original);
+                inViolationAST = ast;
                 return;
             }
         }
@@ -59,6 +66,13 @@ public abstract class AbstractDuplicateCheck extends AbstractCheck {
         checkedAst.put(ast, getFilePath());
     }
 
+    @Override
+    public void leaveToken(DetailAST ast) {
+        if(inViolationAST == ast) {
+            inViolationAST = null;
+        }
+        super.leaveToken(ast);
+    }
 
     /**
      * Logs violations of duplicates.

--- a/src/test/java/edu/byu/cs240/checkstyle/decomposition/DuplicateBlockTest.java
+++ b/src/test/java/edu/byu/cs240/checkstyle/decomposition/DuplicateBlockTest.java
@@ -60,4 +60,11 @@ class DuplicateBlockTest extends CheckTest {
         testFiles(3, fileName);
     }
 
+    @Test
+    @DisplayName("Should find the correct number of errors in code that has nested duplicate blocks")
+    public void should_FindErrors_when_NestedDuplicateBlocks() throws CheckstyleException {
+        String fileName = "testInputs/duplicateBlock/should_FindErrors_when_NestedDuplicateBlocks.java";
+        testFiles(2, fileName);
+    }
+
 }

--- a/src/test/resources/edu/byu/cs240/checkstyle/decomposition/testInputs/duplicateBlock/should_FindErrors_when_NestedDuplicateBlocks.java
+++ b/src/test/resources/edu/byu/cs240/checkstyle/decomposition/testInputs/duplicateBlock/should_FindErrors_when_NestedDuplicateBlocks.java
@@ -1,0 +1,31 @@
+class should_FindErrors_when_DuplicateBlocks {
+    public void hi() {
+        int i = 7;
+        int j = 4;
+        if(i > j) {
+            if (i <= j) {
+                System.out.println(i + j);
+                System.out.println(i - j);
+                System.out.println(j - i);
+            }
+        }
+        i = 2;
+        j = 0;
+        if(i > j) {
+            if (i <= j) {
+                System.out.println(i + j);
+                System.out.println(i - j);
+                System.out.println(j - i);
+            }
+        }
+        i = 17;
+        j = 17;
+        if(i > j) {
+            if (i <= j) {
+                System.out.println(i + j);
+                System.out.println(i - j);
+                System.out.println(j - i);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, if someone has nested duplicate blocks in their code, both are reported as duplicates. This seems unnecessary to me and potentially confusing for the students. This removes that by stopping checking any ast tokens nested inside a ast token that has already been reported as a duplicate.