### PR TITLE
Java 23

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '21'
+          java-version: '23'
 
       - name: Test with Maven
         run: mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -8,15 +8,15 @@
 	<version>1.0.9</version>
 	<name>C S 240 Checkstyle Checks</name>
 	<properties>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>23</maven.compiler.source>
+		<maven.compiler.target>23</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>com.puppycrawl.tools</groupId>
 			<artifactId>checkstyle</artifactId>
-			<version>10.14.1</version>
+			<version>13.5.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/src/main/resources/cs240_checks.xml
+++ b/src/main/resources/cs240_checks.xml
@@ -41,17 +41,17 @@
                      value="Parameter name ''{0}'' must match pattern ''{1}'' (lowerCamelCase)."/>
         </module>
         <module name="LambdaParameterName">
-            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*|_$"/>
             <message key="name.invalidPattern"
                      value="Lambda parameter name ''{0}'' must match pattern ''{1}'' (lowerCamelCase)."/>
         </module>
         <module name="CatchParameterName">
-            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*|_$"/>
             <message key="name.invalidPattern"
                      value="Catch parameter name ''{0}'' must match pattern ''{1}'' (lowerCamelCase)."/>
         </module>
         <module name="LocalVariableName">
-            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*|_$"/>
             <message key="name.invalidPattern"
                      value="Local variable name ''{0}'' must match pattern ''{1}'' (lowerCamelCase)."/>
         </module>
@@ -61,7 +61,7 @@
                      value="Local variable name ''{0}'' must match pattern ''{1}'' (lowerCamelCase)."/>
         </module>
         <module name="PatternVariableName">
-            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+            <property name="format" value="^[a-z][a-zA-Z0-9]*|_$"/>
             <message key="name.invalidPattern"
                      value="Pattern variable name ''{0}'' must match pattern ''{1}'' (lowerCamelCase)."/>
         </module>


### PR DESCRIPTION
This PR is a prerequisite to upgrading the version of Java that runs on the autograder.

The build script was changed, compiling the jar with Java 23 and the lastest version of Checkstyle.

The xml with the custom checks was changed, allowing for unnamed variables. These are denoted by an underscore (see [here](https://openjdk.org/jeps/456) for more information. As per the documentation, the following are allowed to be unnamed variables:

- Lambda Parameters
- Catch Parameters
- Local Variables (_not_ final local variables)
- Pattern Variables